### PR TITLE
z-index customisation for usager marker

### DIFF
--- a/src/features/cartography/infrastructure/presentation/components/leaflet-map/leaflet-map.component.ts
+++ b/src/features/cartography/infrastructure/presentation/components/leaflet-map/leaflet-map.component.ts
@@ -67,7 +67,11 @@ export class LeafletMapComponent implements AfterViewInit, OnChanges {
     this._markersLayer = geoJSON(this.markers, {
       // eslint-disable-next-line @typescript-eslint/typedef,@typescript-eslint/naming-convention
       pointToLayer: (feature: Feature<Point, MarkerProperties>, position: LatLng): Layer =>
-        marker(position, { icon: this.markersConfigurations[feature.properties.markerIconConfiguration](feature) })
+        marker(position, {
+          icon: this.markersConfigurations[feature.properties.markerIconConfiguration](feature),
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          zIndexOffset: feature.properties['zIndexOffset'] ?? 0
+        })
     });
     this._map.addLayer(this._markersLayer);
   }

--- a/src/features/cartography/infrastructure/presentation/pipes/add-usager-marker.pipe.spec.ts
+++ b/src/features/cartography/infrastructure/presentation/pipes/add-usager-marker.pipe.spec.ts
@@ -58,7 +58,8 @@ describe('AddUsagerMarker pipe', (): void => {
             type: 'Point'
           },
           properties: {
-            markerIconConfiguration: Marker.Usager
+            markerIconConfiguration: Marker.Usager,
+            zIndexOffset: 1000
           },
           type: 'Feature'
         }

--- a/src/features/cartography/infrastructure/presentation/pipes/add-usager-marker.pipe.ts
+++ b/src/features/cartography/infrastructure/presentation/pipes/add-usager-marker.pipe.ts
@@ -11,7 +11,8 @@ const usagerFeatureMarker = (usagerCoordinates: Coordinates): Feature<Point, Mar
     type: 'Point'
   },
   properties: {
-    markerIconConfiguration: Marker.Usager
+    markerIconConfiguration: Marker.Usager,
+    zIndexOffset: 1000
   },
   type: 'Feature'
 });


### PR DESCRIPTION
## Description
Fait en sorte que le marqueur usager soit toujours au dessus des autres marqueurs sur la carte.

Testez la démo [ici]()