### PR TITLE
Passage du reverse geocoding d'addresse sur Nominem Open Street Map

### DIFF
--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -5,7 +5,7 @@ import { Api } from './environment.model';
 // TODO Passer en var d'env
 export const ENVIRONMENT: EnvironmentModel = {
   apisConfiguration: {
-    [Api.Adresse]: { domain: 'https://api-adresse.data.gouv.fr' },
+    [Api.Adresse]: { domain: 'https://nominatim.openstreetmap.org' },
     [Api.ConseillerNumerique]: { domain: 'https://api.conseiller-numerique.gouv.fr' }
   },
   type: EnvironmentType.Production

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,7 @@ import { Api } from './environment.model';
 // TODO Passer en var d'env
 export const ENVIRONMENT: EnvironmentModel = {
   apisConfiguration: {
-    [Api.Adresse]: { domain: 'https://api-adresse.data.gouv.fr' },
+    [Api.Adresse]: { domain: 'https://nominatim.openstreetmap.org' },
     [Api.ConseillerNumerique]: { domain: 'https://api.conseiller-numerique.gouv.fr' }
   },
   type: EnvironmentType.Development

--- a/src/features/cartography/infrastructure/data/rest/coordinates/coordinates.rest.ts
+++ b/src/features/cartography/infrastructure/data/rest/coordinates/coordinates.rest.ts
@@ -15,7 +15,7 @@ import { Api } from '../../../../../../environments/environment.model';
 
 @Injectable()
 export class CoordinatesRest extends CoordinatesRepository {
-  private readonly _queryParameters: string = '?q=';
+  private readonly _queryParameters: string = '?format=geojson&q=';
   private readonly _searchEndpoint: string = 'search';
 
   public constructor(@Inject(HttpClient) private readonly httpClient: HttpClient) {


### PR DESCRIPTION
## Description 

https://nominatim.org/release-docs/develop/api/Search/

Permet notamment de geocoder des code postaux directement.

Testez la démo [ici](https://app-59b24783-7cd5-41d9-b076-c7e85f1b6d61.cleverapps.io)