### PR TITLE
Centrer la vue sur un point d'intérêt

### DIFF
--- a/src/features/cartography/infrastructure/data/rest/coordinates/coordinates.rest.ts
+++ b/src/features/cartography/infrastructure/data/rest/coordinates/coordinates.rest.ts
@@ -8,7 +8,7 @@ import { Api } from '../../../../../../environments/environment.model';
 
 @Injectable()
 export class CoordinatesRest extends CoordinatesRepository {
-  private readonly _queryParameters: string = '?format=geojson&q=';
+  private readonly _queryParameters: string = '?format=geojson&countrycodes=FR&q=';
   private readonly _searchEndpoint: string = 'search';
 
   public constructor(@Inject(HttpClient) private readonly httpClient: HttpClient) {

--- a/src/features/cartography/infrastructure/presentation/models/cnfs/cnfs.presentation-model.ts
+++ b/src/features/cartography/infrastructure/presentation/models/cnfs/cnfs.presentation-model.ts
@@ -1,12 +1,19 @@
 import { Feature, FeatureCollection, GeoJsonProperties, Point } from 'geojson';
 import { Marker } from '../../../configuration';
 import { AnyGeoJsonProperty } from '../../../../../../environments/environment.model';
+import { Coordinates } from '../../../../core';
 
 export type MarkerProperties = GeoJsonProperties & { markerIconConfiguration: Marker };
+
+export interface CenterView {
+  coordinates: Coordinates;
+  zoomLevel: number;
+}
 
 export interface MarkerEvent {
   eventType: string;
   markerProperties: AnyGeoJsonProperty;
+  markerPosition: Coordinates;
 }
 
 export const EMPTY_FEATURE_COLLECTION: FeatureCollection<Point, MarkerProperties> = {

--- a/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.page.html
+++ b/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.page.html
@@ -16,8 +16,9 @@
       <leaflet-map
         [mapOptions]="mapOptions"
         [markers]="visibleMarkers | addUsagerMarker:(usagerCoordinates$ | async)"
-        (stateChange)="mapViewChanged($event)"
-        (markerChange)="log($event)"></leaflet-map>
+        [centerView]="centerView$ | async"
+        (markerChange)="markerEvent($event)"
+        (stateChange)="mapViewChanged($event)"></leaflet-map>
     </div>
   </div>
 </ng-container>


### PR DESCRIPTION
## Description
Centre la vue :
- au clic sur un marqueur.
- à la géolocalisation automatique 
- à la géolocalisation manuelle

Restreint la géolocalisation au sur les localisations FR (inclu les DOM/TOM etc...)

Testez la démo [ici](https://app-78e189f1-2f00-4d89-8552-2111b64f6653.cleverapps.io/cartographie)