### PR TITLE
add center view for regions markers and user location

### DIFF
--- a/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.page.html
+++ b/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.page.html
@@ -22,7 +22,9 @@
     <ng-container *ngIf="regionMarkers$ | async as regionMarkers">
       <leaflet-map
         [mapOptions]="cartographyConfiguration"
+        [centerView]="centerView"
         [markers]="regionMarkers | addUsagerMarker:(usagerCoordinates$ | async)"
+        (markerChange)="onMarkerChanged($event)"
         (stateChange)="mapViewChanged($event)"></leaflet-map>
     </ng-container>
   </div>

--- a/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.page.spec.ts
+++ b/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.page.spec.ts
@@ -10,9 +10,14 @@ import { CnfsListStubComponent } from '../../test-doubles/components/cnfs-list/c
 import { AddressGeolocationStubComponent } from '../../test-doubles/components/address-geolocation/address-geolocation.component.stub';
 import { LeafletMapStubComponent } from '../../test-doubles/components/leaflet-map/leaflet-map.component.stub';
 import { CARTOGRAPHY_TOKEN } from '../../../configuration';
+import { CenterView } from '../../models';
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 class CartographyPresenterStub {
+  public centerView(): CenterView {
+    return {} as CenterView;
+  }
+
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   public defaultMapOptions() {
     return {};

--- a/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.presenter.spec.ts
+++ b/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.presenter.spec.ts
@@ -70,16 +70,18 @@ describe('cartography presenter', (): void => {
   });
 
   it('should map a markerEvent to a CenterView', (): void => {
+    const palaisDeLElyseeCoordinates: Coordinates = new Coordinates(48.87063, 2.316934);
+
     const markerEvent: MarkerEvent = {
       eventType: 'click',
-      markerPosition: new Coordinates(2.775278, 49.966111),
+      markerPosition: palaisDeLElyseeCoordinates,
       markerProperties: {
         boundingZoom: 8
       }
     };
 
     const expectedCenterView: CenterView = {
-      coordinates: new Coordinates(2.775278, 49.966111),
+      coordinates: palaisDeLElyseeCoordinates,
       zoomLevel: 8
     };
 
@@ -87,10 +89,10 @@ describe('cartography presenter', (): void => {
   });
 
   it('should create a CenterView from map coordinates', (): void => {
-    const usagerCoordinates: Coordinates = new Coordinates(2.775278, 49.966111);
+    const usagerCoordinates: Coordinates = new Coordinates(48.87063, 2.316934);
 
     const expectedCenterView: CenterView = {
-      coordinates: new Coordinates(2.775278, 49.966111),
+      coordinates: usagerCoordinates,
       zoomLevel: 12
     };
 

--- a/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.presenter.spec.ts
+++ b/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.presenter.spec.ts
@@ -1,11 +1,11 @@
-import { CartographyPresenter } from './cartography.presenter';
+import { CartographyPresenter, coordinatesToCenterView, markerEventToCenterView } from './cartography.presenter';
 import { ListCnfsPositionUseCase, ListCnfsByRegionUseCase } from '../../../../use-cases';
 import { GeocodeAddressUseCase } from '../../../../use-cases/geocode-address/geocode-address.use-case';
 import { ClusterService } from '../../services/cluster.service';
 import { firstValueFrom, Observable, of } from 'rxjs';
 import { FeatureCollection, Point } from 'geojson';
 import { CnfsByRegion, Coordinates } from '../../../../core';
-import { MarkerProperties } from '../../models';
+import { CenterView, MarkerEvent, MarkerProperties } from '../../models';
 import { Marker } from '../../../configuration';
 
 const LIST_CNFS_BY_REGION_USE_CASE: ListCnfsByRegionUseCase = {
@@ -67,5 +67,33 @@ describe('cartography presenter', (): void => {
     );
 
     expect(cnfsByRegionPositions).toStrictEqual(expectedCnfsByRegionPositions);
+  });
+
+  it('should map a markerEvent to a CenterView', (): void => {
+    const markerEvent: MarkerEvent = {
+      eventType: 'click',
+      markerPosition: new Coordinates(2.775278, 49.966111),
+      markerProperties: {
+        boundingZoom: 8
+      }
+    };
+
+    const expectedCenterView: CenterView = {
+      coordinates: new Coordinates(2.775278, 49.966111),
+      zoomLevel: 8
+    };
+
+    expect(markerEventToCenterView(markerEvent)).toStrictEqual(expectedCenterView);
+  });
+
+  it('should create a CenterView from map coordinates', (): void => {
+    const usagerCoordinates: Coordinates = new Coordinates(2.775278, 49.966111);
+
+    const expectedCenterView: CenterView = {
+      coordinates: new Coordinates(2.775278, 49.966111),
+      zoomLevel: 12
+    };
+
+    expect(coordinatesToCenterView(usagerCoordinates)).toStrictEqual(expectedCenterView);
   });
 });

--- a/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.presenter.ts
+++ b/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.presenter.ts
@@ -3,7 +3,6 @@ import {
   listCnfsByRegionToPresentation,
   cnfsCoreToPresentation,
   MarkersPresentation,
-  MarkerProperties,
   CenterView,
   MarkerEvent
 } from '../../models';
@@ -56,7 +55,7 @@ export class CartographyPresenter {
     );
   }
 
-  public listCnfsByRegionPositions$(): Observable<FeatureCollection<Point, MarkerProperties>> {
+  public listCnfsByRegionPositions$(): Observable<MarkersPresentation> {
     return this.listCnfsByRegionUseCase.execute$().pipe(map(listCnfsByRegionToPresentation));
   }
 

--- a/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.presenter.ts
+++ b/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.presenter.ts
@@ -1,5 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
-import { listCnfsByRegionToPresentation, cnfsCoreToPresentation, MarkersPresentation, MarkerProperties } from '../../models';
+import {
+  listCnfsByRegionToPresentation,
+  cnfsCoreToPresentation,
+  MarkersPresentation,
+  MarkerProperties,
+  CenterView,
+  MarkerEvent
+} from '../../models';
 import { Coordinates } from '../../../../core';
 import { map, Observable, switchMap } from 'rxjs';
 import { ListCnfsByRegionUseCase, ListCnfsPositionUseCase } from '../../../../use-cases';
@@ -9,6 +16,18 @@ import { ClusterService } from '../../services/cluster.service';
 import { AnyGeoJsonProperty } from '../../../../../../environments/environment.model';
 import { combineLatestWith } from 'rxjs/operators';
 import { ViewBox } from '../../directives/leaflet-map-state-change';
+
+const CITY_ZOOM_LEVEL: number = 12;
+
+export const markerEventToCenterView = (markerEvent: MarkerEvent): CenterView => ({
+  coordinates: markerEvent.markerPosition,
+  zoomLevel: markerEvent.markerProperties['boundingZoom'] as number
+});
+
+export const coordinatesToCenterView = (coordinates: Coordinates): CenterView => ({
+  coordinates,
+  zoomLevel: CITY_ZOOM_LEVEL
+});
 
 @Injectable()
 export class CartographyPresenter {
@@ -31,7 +50,6 @@ export class CartographyPresenter {
       type: 'FeatureCollection'
     });
   }
-
   public geocodeAddress$(addressToGeocode$: Observable<string>): Observable<Coordinates> {
     return addressToGeocode$.pipe(
       switchMap((address: string): Observable<Coordinates> => this.geocodeAddressUseCase.execute$(address))


### PR DESCRIPTION
## Description

- Ajout du zoom et de la localisation sur les marqueurs des régions au clic en tenant compte du niveau de zoom associé à la région
- Ajout du zoom et de la localisation sur le marqueur usager lorsqu'il recherche une adresse ou qu'il se géolocalise

[Tester la démo](https://app-0a72ce22-19c2-4500-bb5b-ffe8af081bfb.cleverapps.io/cartographie)