### PR TITLE
Feat using address and geo apis for geocode

### DIFF
--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -3,6 +3,7 @@ import { ApiConfiguration } from '../app/tokens';
 
 export enum Api {
   Adresse = '@adresse',
+  Geo = '@geo',
   ConseillerNumerique = '@conseillerNumerique'
 }
 

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -4,7 +4,8 @@ import { Api, EnvironmentModel } from './environment.model';
 // TODO Passer en var d'env
 export const ENVIRONMENT: EnvironmentModel = {
   apisConfiguration: {
-    [Api.Adresse]: { domain: 'https://nominatim.openstreetmap.org' },
+    [Api.Adresse]: { domain: 'https://api-adresse.data.gouv.fr' },
+    [Api.Geo]: { domain: 'https://geo.api.gouv.fr' },
     [Api.ConseillerNumerique]: { domain: 'https://api.conseiller-numerique.gouv.fr' }
   },
   type: EnvironmentType.Production

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,8 @@ import { Api, EnvironmentModel } from './environment.model';
 // TODO Passer en var d'env
 export const ENVIRONMENT: EnvironmentModel = {
   apisConfiguration: {
-    [Api.Adresse]: { domain: 'https://nominatim.openstreetmap.org' },
+    [Api.Adresse]: { domain: 'https://api-adresse.data.gouv.fr' },
+    [Api.Geo]: { domain: 'https://geo.api.gouv.fr' },
     [Api.ConseillerNumerique]: { domain: 'https://api.conseiller-numerique.gouv.fr' }
   },
   type: EnvironmentType.Development

--- a/src/features/cartography/infrastructure/data/rest/coordinates/coordinates-helpers.spec.ts
+++ b/src/features/cartography/infrastructure/data/rest/coordinates/coordinates-helpers.spec.ts
@@ -1,0 +1,15 @@
+import { capturePostalCode } from './coordinates-helpers';
+
+describe('capturePostalCode coordinates helper', (): void => {
+  it('should return hasPostalCode at false if no postal code present in the query', (): void => {
+    const addressString: string = '18 Avenue des Canuts, Poitiers';
+
+    expect(capturePostalCode(addressString).hasPostalCode).toBe(false);
+  });
+
+  it('should return the postal code (5 consecutive digits) if present', (): void => {
+    const addressString: string = '18 Avenue des Canuts, 69120';
+
+    expect(capturePostalCode(addressString).capturedPostalCode).toBe('69120');
+  });
+});

--- a/src/features/cartography/infrastructure/data/rest/coordinates/coordinates-helpers.ts
+++ b/src/features/cartography/infrastructure/data/rest/coordinates/coordinates-helpers.ts
@@ -1,0 +1,10 @@
+import { PostalCodeRegexResult } from './coordinates.rest';
+
+export const capturePostalCode = (addressString: string): PostalCodeRegexResult => {
+  const capturePostalCodeRegex: RegExp = /(?<postalCode>[0-9]{5})/u;
+  const capturedGroups: RegExpExecArray | null = capturePostalCodeRegex.exec(addressString);
+  return {
+    capturedPostalCode: capturedGroups?.groups?.['postalCode'] ?? '',
+    hasPostalCode: capturedGroups !== null
+  };
+};

--- a/src/features/cartography/infrastructure/data/rest/coordinates/coordinates.rest.ts
+++ b/src/features/cartography/infrastructure/data/rest/coordinates/coordinates.rest.ts
@@ -1,25 +1,78 @@
-import { Observable, map } from 'rxjs';
+import { Observable, map, switchMap } from 'rxjs';
 import { Inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Coordinates, CoordinatesRepository } from '../../../../core';
 import { FeatureCollection, Point } from 'geojson';
 import { featureCollectionToFirstCoordinates } from '../../models/coordinates.transfer-mapper';
 import { Api } from '../../../../../../environments/environment.model';
+import { capturePostalCode } from './coordinates-helpers';
+
+interface ApiGeoResult {
+  nom: string;
+}
+
+export interface PostalCodeRegexResult {
+  capturedPostalCode: string;
+  hasPostalCode: boolean;
+}
+
+const replacePostalCodeByLocalityName = (addressQuery: string, postalCode: string, localityName: string): string =>
+  addressQuery.replace(postalCode, localityName);
+
+const firstResultLocalityNameOrEmpty = (geoResult: ApiGeoResult[]): string => (geoResult.length > 0 ? geoResult[0].nom : '');
 
 @Injectable()
 export class CoordinatesRest extends CoordinatesRepository {
-  private readonly _queryParameters: string = '?format=geojson&countrycodes=FR&q=';
-  private readonly _searchEndpoint: string = 'search';
+  private readonly _addressQueryParameters: string = '?q=';
+  private readonly _addressSearchEndpoint: string = 'search';
+
+  private readonly _geoCodePostalParameter: string = 'codePostal=';
+  private readonly _geoCommunesEndpoint: string = 'communes';
 
   public constructor(@Inject(HttpClient) private readonly httpClient: HttpClient) {
     super();
   }
 
-  public geocodeAddress$(addressQuery: string): Observable<Coordinates> {
+  private combinedGeoAndAddressRequests$(postalCode: string, addressQuery: string): Observable<Coordinates> {
+    const getAddressApiFullUrlWithLocality = (localityName: string): string =>
+      this.getAddressApiFullUrl(replacePostalCodeByLocalityName(addressQuery, postalCode, localityName));
+
     return this.httpClient
-      .get<FeatureCollection<Point>>(
-        `${Api.Adresse}/${this._searchEndpoint}/${this._queryParameters}${encodeURI(addressQuery)}`
-      )
+      .get<ApiGeoResult[]>(this.getGeoApiFullUrl(postalCode))
+      .pipe(switchMap(this.completedAddressRequest$(getAddressApiFullUrlWithLocality)));
+  }
+
+  private completedAddressRequest$(
+    getAddressApiFullUrlWithLocality: (localityName: string) => string
+  ): (geoResult: ApiGeoResult[]) => Observable<Coordinates> {
+    return (geoResult: ApiGeoResult[]): Observable<Coordinates> => {
+      const localityNameByPostalCode: string = firstResultLocalityNameOrEmpty(geoResult);
+
+      return this.httpClient
+        .get<FeatureCollection<Point>>(getAddressApiFullUrlWithLocality(localityNameByPostalCode))
+        .pipe(map(featureCollectionToFirstCoordinates));
+    };
+  }
+
+  private getAddressApiFullUrl(addressQuery: string): string {
+    return `${Api.Adresse}/${this._addressSearchEndpoint}/${this._addressQueryParameters}${encodeURI(addressQuery)}`;
+  }
+
+  private getGeoApiFullUrl(postalCode: string): string {
+    return`${Api.Geo}/${this._geoCommunesEndpoint}?${this._geoCodePostalParameter}${postalCode}`;
+  }
+
+  private simpleAddressRequest$(addressQuery: string): Observable<Coordinates> {
+    return this.httpClient
+      .get<FeatureCollection<Point>>(this.getAddressApiFullUrl(addressQuery))
       .pipe(map(featureCollectionToFirstCoordinates));
+  }
+
+  public geocodeAddress$(addressQuery: string): Observable<Coordinates> {
+    const { capturedPostalCode, hasPostalCode }: PostalCodeRegexResult = capturePostalCode(addressQuery);
+
+    return hasPostalCode
+      ? this.combinedGeoAndAddressRequests$(capturedPostalCode, addressQuery)
+      : this.simpleAddressRequest$(addressQuery);
   }
 }


### PR DESCRIPTION
## Description
Remplace le geocoding d'adresse par une combinaison d'appels aux api geo et adresse. 
En cas d'erreur sur le geocoding d'adresse, met une erreur dans une propriété de la page.

Sur certains code postaux de COM, l'api adresse fait défaut ces cas seront traités plus tard une fois identifiés.

Cas identifiés pour l'instant :
97133
