### PR TITLE
Feature: Comportement spécifique pour la Guyane

### DIFF
--- a/.eslint/eslint-test.rules.js
+++ b/.eslint/eslint-test.rules.js
@@ -8,5 +8,6 @@ module.exports = {
       skipComments: true
     }
   ],
-  'max-nested-callbacks': ['error', 4]
+  'max-nested-callbacks': ['error', 4],
+  'max-statements': 'off'
 };

--- a/.eslint/eslint.rules.js
+++ b/.eslint/eslint.rules.js
@@ -108,7 +108,7 @@ module.exports = {
   'max-lines': [
     'error',
     {
-      max: 128,
+      max: 256,
       skipBlankLines: true,
       skipComments: true
     }

--- a/src/features/cartography/infrastructure/presentation/components/leaflet-map/leaflet-map.component.ts
+++ b/src/features/cartography/infrastructure/presentation/components/leaflet-map/leaflet-map.component.ts
@@ -48,8 +48,7 @@ const MAP_OPTIONS: LeafletMapOptions = {
   maxZoom: 18,
   minZoom: 2.5,
   zoomAnimationThreshold: 12,
-  zoomControl: false,
-  zoomDelta: 0.5
+  zoomControl: false
 };
 // TODO Convert configuration to injected token for default options then remove
 const DEFAULT_LONGITUDE: number = 4.468874066180609;

--- a/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.page.html
+++ b/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.page.html
@@ -18,7 +18,8 @@
         [centerView]="centerView"
         [markers]="markers"
         (markerChange)="onMarkerChanged($event)"
-        (stateChange)="onMapViewChanged($event)"></leaflet-map>
+        (stateChange)="onMapViewChanged($event)"
+        (zoomOut)="onZoomOut()"></leaflet-map>
     </ng-container>
   </div>
 </div>

--- a/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.presenter.spec.ts
+++ b/src/features/cartography/infrastructure/presentation/pages/cartography/cartography.presenter.spec.ts
@@ -204,6 +204,169 @@ describe('cartography presenter', (): void => {
       expect(visibleMapPointsOfInterest).toStrictEqual(expectedCnfsByDepartmentFeatures);
     });
 
+    it('should display cnfs permanences at department zoom level if marker display is forced', async (): Promise<void> => {
+      const forceCnfsPermanenceDisplay$: Observable<boolean> = of(true);
+      const viewCullingService: MapViewCullingService = new MapViewCullingService();
+      const listCnfsByDepartmentUseCase: ListCnfsByDepartmentUseCase = {
+        execute$(): Observable<CnfsByDepartment[]> {
+          return of([
+            new CnfsByDepartment(new Coordinates(3.922060670769425, -53.237712294069844), {
+              boundingZoom: 10,
+              code: '973',
+              count: 27,
+              department: 'Guyane'
+            })
+          ]);
+        }
+      } as ListCnfsByDepartmentUseCase;
+
+      const listCnfsUseCase: ListCnfsUseCase = {
+        execute$(): Observable<Cnfs[]> {
+          return of([
+            new Cnfs(new Coordinates(4.33889, -50.125782), {
+              cnfs: {
+                email: 'mary.doe@conseiller-numerique.fr',
+                name: 'Mary Doe'
+              },
+              structure: {
+                address: '31 Avenue de la mer, 13003 Cayenne',
+                isLabeledFranceServices: true,
+                name: 'Médiathèque de la mer',
+                phone: '0478563641',
+                type: ''
+              }
+            })
+          ]);
+        }
+      } as ListCnfsUseCase;
+
+      const expectedCnfsPermanenceMarkersFeatures: Feature<Point, MarkerProperties<CnfsPermanenceProperties>>[] = [
+        {
+          geometry: {
+            coordinates: [-50.125782, 4.33889],
+            type: 'Point'
+          },
+          properties: {
+            cnfs: [
+              {
+                email: 'mary.doe@conseiller-numerique.fr',
+                name: 'Mary Doe'
+              }
+            ],
+            markerType: Marker.CnfsPermanence,
+            structure: {
+              address: '31 Avenue de la mer, 13003 Cayenne',
+              isLabeledFranceServices: true,
+              name: 'Médiathèque de la mer',
+              phone: '0478563641',
+              type: ''
+            }
+          },
+          type: 'Feature'
+        }
+      ];
+
+      const cartographyPresenter: CartographyPresenter = new CartographyPresenter(
+        LIST_CNFS_BY_REGION_USE_CASE,
+        listCnfsByDepartmentUseCase,
+        listCnfsUseCase,
+        {} as GeocodeAddressUseCase,
+        viewCullingService
+      );
+
+      const viewportAndZoom$: Observable<ViewportAndZoom> = of({
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        viewport: [-55, 1, -49, 5],
+        zoomLevel: DEPARTMENT_ZOOM_LEVEL
+      });
+
+      const visibleMapPointsOfInterest: Feature<Point, PointOfInterestMarkerProperties>[] = await firstValueFrom(
+        cartographyPresenter.visibleMapPointsOfInterestThroughViewportAtZoomLevel$(
+          viewportAndZoom$,
+          forceCnfsPermanenceDisplay$
+        )
+      );
+
+      expect(visibleMapPointsOfInterest).toStrictEqual(expectedCnfsPermanenceMarkersFeatures);
+    });
+
+    it('should display cnfs by department at depatment zoom level if marker display is not forced', async (): Promise<void> => {
+      const forceCnfsPermanenceDisplay$: Observable<boolean> = of(false);
+      const viewCullingService: MapViewCullingService = new MapViewCullingService();
+      const listCnfsByDepartmentUseCase: ListCnfsByDepartmentUseCase = {
+        execute$(): Observable<CnfsByDepartment[]> {
+          return of([
+            new CnfsByDepartment(new Coordinates(3.922060670769425, -53.237712294069844), {
+              boundingZoom: 10,
+              code: '973',
+              count: 27,
+              department: 'Guyane'
+            })
+          ]);
+        }
+      } as ListCnfsByDepartmentUseCase;
+
+      const listCnfsUseCase: ListCnfsUseCase = {
+        execute$(): Observable<Cnfs[]> {
+          return of([
+            new Cnfs(new Coordinates(4.33889, -50.125782), {
+              cnfs: {
+                email: 'mary.doe@conseiller-numerique.fr',
+                name: 'Mary Doe'
+              },
+              structure: {
+                address: '31 Avenue de la mer, 13003 Cayenne',
+                isLabeledFranceServices: true,
+                name: 'Médiathèque de la mer',
+                phone: '0478563641',
+                type: ''
+              }
+            })
+          ]);
+        }
+      } as ListCnfsUseCase;
+
+      const expectedCnfsByDepartmentMarkersFeatures: Feature<Point, MarkerProperties<CnfsByDepartmentProperties>>[] = [
+        {
+          geometry: {
+            coordinates: [-53.237712294069844, 3.922060670769425],
+            type: 'Point'
+          },
+          properties: {
+            boundingZoom: 10,
+            code: '973',
+            count: 27,
+            department: 'Guyane',
+            markerType: Marker.CnfsByDepartment
+          },
+          type: 'Feature'
+        }
+      ];
+
+      const cartographyPresenter: CartographyPresenter = new CartographyPresenter(
+        LIST_CNFS_BY_REGION_USE_CASE,
+        listCnfsByDepartmentUseCase,
+        listCnfsUseCase,
+        {} as GeocodeAddressUseCase,
+        viewCullingService
+      );
+
+      const viewportAndZoom$: Observable<ViewportAndZoom> = of({
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        viewport: [-55, 1, -49, 5],
+        zoomLevel: DEPARTMENT_ZOOM_LEVEL
+      });
+
+      const visibleMapPointsOfInterest: Feature<Point, PointOfInterestMarkerProperties>[] = await firstValueFrom(
+        cartographyPresenter.visibleMapPointsOfInterestThroughViewportAtZoomLevel$(
+          viewportAndZoom$,
+          forceCnfsPermanenceDisplay$
+        )
+      );
+
+      expect(visibleMapPointsOfInterest).toStrictEqual(expectedCnfsByDepartmentMarkersFeatures);
+    });
+
     it('should display all cnfs permanences if zoomed more than the department level', async (): Promise<void> => {
       const viewCullingService: MapViewCullingService = new MapViewCullingService();
       const cartographyPresenter: CartographyPresenter = new CartographyPresenter(


### PR DESCRIPTION
## Description
- Ajoute un comportement spécifique d'éclatement des permanences pour la guyane :
  - activé au clic sur un pin de région ou de département.
  - désactivé au de-zoom

- bonus : fixe le bouton '-' du zoom qui ne marchait pas
 
[Testez la démo ici](https://app-c1f4085f-de98-4db0-9d63-a8f70bb9eabe.cleverapps.io)
