### PR TITLE
filter empty opening hours in permanence opening hours component

### DIFF
--- a/src/features/cartography/infrastructure/presentation/components/cnfs-details/permanence-opening-hours/permanence-opening-hours.component.html
+++ b/src/features/cartography/infrastructure/presentation/components/cnfs-details/permanence-opening-hours/permanence-opening-hours.component.html
@@ -3,10 +3,13 @@
   Horaires
 </h2>
 <table class="fr-full-container--width fr-mb-2w" *ngIf="opening.length > 0; else noOpeningHours">
-  <tr *ngFor="let opening of opening; index as i; trackBy: trackByOpeningDay">
-    <td>{{ opening.day | slice: 0:3 }}.</td>
-    <td class="fr-text-label--grey">{{ opening.hours }}</td>
-  </tr>
+  <ng-container *ngFor="let opening of opening; index as i; trackBy: trackByOpeningDay">
+    <tr *ngIf="opening.hours !== ''">
+      <td>{{ opening.day | slice: 0:3 }}.</td>
+      <td class="fr-text-label--grey">{{ opening.hours }}</td>
+    </tr>
+  </ng-container>
+
 </table>
 <ng-template #noOpeningHours>
   <p>Aucun horaire disponible pour cette structure</p>


### PR DESCRIPTION
## Description

Fix display only non empty opening hours in permanence details page.

[Demo](https://app-c2aa7640-9596-4f6a-a9bf-9a1a33f5b7b0.cleverapps.io/)